### PR TITLE
Add project setting for unicode isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ func _notification(what: int) -> void:
 
 ## Project Settings
 
+* `internationalization/fluent/use_unicode_isolation`: When mixing RTL with LTR languages, enable this to insert additional control characters for forcing the correct reading direction. See [this page](https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation) for a more detailed explanation.
 * `internationalization/fluent/parse_args_in_message`: Decides whether variables can be filled via the message parameter. This is the only way to pass args when using the [Default](#default) version, so only makes sense to use in that case.
 * `internationalization/fluent/locale_by_file_regex`: If specified, file name is first checked for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.
 * `internationalization/fluent/locale_by_folder_regex`: If specified, the folder hierarchy is secondly traversed to check for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.

--- a/rust/src/fluent/project_settings.rs
+++ b/rust/src/fluent/project_settings.rs
@@ -5,6 +5,7 @@ use constcat::concat as constcat;
 
 const PROJECT_SETTING_PREFIX: &str = "internationalization/fluent/";
 pub(crate) const PROJECT_SETTING_FALLBACK_LOCALE: &str = "internationalization/locale/fallback";
+pub(crate) const PROJECT_SETTING_UNICODE_ISOLATION: &str = constcat!(PROJECT_SETTING_PREFIX, "use_unicode_isolation");
 pub(crate) const PROJECT_SETTING_PARSE_ARGS_IN_MESSAGE: &str = constcat!(PROJECT_SETTING_PREFIX, "parse_args_in_message");
 pub(crate) const PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "locale_by_folder_regex");
 pub(crate) const PROJECT_SETTING_LOCALE_BY_FILE_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "locale_by_file_regex");
@@ -16,6 +17,7 @@ pub(crate) const INVALID_MESSAGE_HANDLING_SKIP: i32 = 0;
 pub(crate) const INVALID_MESSAGE_HANDLING_CONVERT_TO_VALID: i32 = 1;
 
 pub fn register() {
+    register_setting(PROJECT_SETTING_UNICODE_ISOLATION.to_string(), false.to_variant());
     // Default to true for default builds (no args parameter), false for forked builds.
     register_setting(PROJECT_SETTING_PARSE_ARGS_IN_MESSAGE.to_string(), cfg!(not(feature = "forked-godot")).to_variant());
     register_setting(PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX.to_string(), "^.+$".to_variant());


### PR DESCRIPTION
Fixes #30

Setting is disabled by default, since RTL is rarely used in games.