### PR TITLE
Add message pattern matching system

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,34 @@ func _notification(what: int) -> void:
 
 ## Project Settings
 
+> [!TIP]
+> If you don't see some of these settings, make sure you have Advanced Settings enabled.
+
+### General
+
+* `Localization` tab → `Translations` tab: Add .ftl files in this page to automatically load them on startup (Forked version only).
+* `internationalization/locale/fallback`: Fallback locale is used when the selected language does not have a date/time/number formatter available.
 * `internationalization/fluent/use_unicode_isolation`: When mixing RTL with LTR languages, enable this to insert additional control characters for forcing the correct reading direction. See [this page](https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation) for a more detailed explanation.
 * `internationalization/fluent/parse_args_in_message`: Decides whether variables can be filled via the message parameter. This is the only way to pass args when using the [Default](#default) version, so only makes sense to use in that case.
-* `internationalization/fluent/locale_by_file_regex`: If specified, file name is first checked for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.
-* `internationalization/fluent/locale_by_folder_regex`: If specified, the folder hierarchy is secondly traversed to check for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.
+
+### Loader
+
+These settings only apply to translation files loaded by `load()` or via project settings.
+For manually created `TranslationFluent` instances, custom logic can be implemented to emulate these settings.
+
+* `internationalization/fluent/loader/locale_by_file_regex`: If specified, file name is first checked for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.
+* `internationalization/fluent/loader/locale_by_folder_regex`: If specified, the folder hierarchy is secondly traversed to check for locale via regex. Can contain a capture group which matches a possible locale. Always case-insensitive.
+* `internationalization/fluent/loader/pattern_by_file_regex`: If specified, file name is first checked for message pattern via regex. Can contain capture groups which can later be used construct the message pattern. Can be made case-insensitive by prefixing with `(?i)`.
+* `internationalization/fluent/loader/pattern_by_folder_regex`: If specified, the folder hierarchy is secondly traversed to check for message pattern via regex. Can contain capture groups which can later be used construct the message pattern. Can be made case-insensitive by prefixing with `(?i)`.
+* `internationalization/fluent/loader/message_pattern`: If specified together with `pattern_by_*_regex`, decides how the pattern should be formatted. The placeholder `{$n}` is replaced with the n-th capture group (so `{$1}` would contain the first capture group that matched). A single capture group like `(.+)` must be specified to capture the actual message. Can be made case-insensitive by prefixing with `(?i)`.
+
+### Generator
+
+These settings apply to the `FluentGenerator` singleton:
+
 * `internationalization/fluent/generator/locales`: See below.
 * `internationalization/fluent/generator/file_patterns`: See below.
 * `internationalization/fluent/generator/invalid_message_handling`: If a message identifier is invalid (e.g. contains symbols or spaces), should it be skipped or should the invalid symbols be replaced with underscores?
-* `Localization` tab → `Translations` tab: Add .ftl files in this page to automatically load them on startup (Forked version only).
-* `internationalization/locale/fallback`: Fallback locale is used when the selected language does not have a date/time/number formatter available.
-
-> [!TIP]
-> If you don't see some of these settings, make sure you have Advanced Settings showing.
 
 ## FTL Generator
 

--- a/rust/src/fluent/locale.rs
+++ b/rust/src/fluent/locale.rs
@@ -4,6 +4,8 @@ use godot::engine::{ProjectSettings, RegEx, RegExMatch};
 use godot::prelude::*;
 use unic_langid::LanguageIdentifier;
 
+use crate::utils::get_single_regex_match;
+
 use super::project_settings::*;
 
 pub fn compute_message_pattern(path: &PathBuf) -> Option<Gd<RegExMatch>> {
@@ -57,16 +59,7 @@ pub fn compute_locale(path: &PathBuf) -> Option<String> {
         let file_regex = "(?i)".to_owned() + &file_regex.to_string();
         let file_regex = RegEx::create_from_string(file_regex.into()).unwrap();
         if let Some(regex_match) = file_regex.search(file_name) {
-            // Ensure there is only one capture group.
-            if regex_match.get_group_count() > 1 {
-                godot_warn!(
-                    "{} is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing. \nUsing last capture group as a fallback.",
-                    PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX, regex_match.get_group_count()
-                );
-            }
-
-            // Get the last capture group's value.
-            let locale = regex_match.get_string_ex().name(regex_match.get_group_count().to_variant()).done().to_string();
+            let locale = get_single_regex_match(regex_match, PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX).to_string();
             if is_valid_locale(&locale) {
                 return Some(locale);
             }
@@ -86,16 +79,7 @@ pub fn compute_locale(path: &PathBuf) -> Option<String> {
             }
 
             if let Some(regex_match) = folder_regex.search(folder.into()) {
-                // Ensure there is only one capture group.
-                if regex_match.get_group_count() > 1 {
-                    godot_warn!(
-                        "{} is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing. \nUsing last capture group as a fallback.",
-                        PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX, regex_match.get_group_count()
-                    );
-                }
-    
-                // Get the last capture group's value.
-                let locale = regex_match.get_string_ex().name(regex_match.get_group_count().to_variant()).done().to_string();
+                let locale = get_single_regex_match(regex_match, PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX).to_string();
                 if is_valid_locale(&locale) {
                     return Some(locale);
                 }

--- a/rust/src/fluent/locale.rs
+++ b/rust/src/fluent/locale.rs
@@ -1,16 +1,55 @@
 use std::path::{self, PathBuf};
 
-use godot::engine::{ProjectSettings, RegEx};
+use godot::engine::{ProjectSettings, RegEx, RegExMatch};
 use godot::prelude::*;
 use unic_langid::LanguageIdentifier;
 
 use super::project_settings::*;
 
+pub fn compute_message_pattern(path: &PathBuf) -> Option<Gd<RegExMatch>> {
+    let project_settings = ProjectSettings::singleton();
+
+    // Requires pattern string as well.
+    if project_settings.get_setting(PROJECT_SETTING_LOADER_MESSAGE_PATTERN.into()).stringify().is_empty() {
+        return None;
+    }
+
+    // 1. File regex.
+    let file_regex = project_settings.get_setting(PROJECT_SETTING_LOADER_PATTERN_BY_FILE_REGEX.into()).stringify();
+    if !file_regex.is_empty() {
+        let file_name = path.file_name()?;
+        let file_name = GString::from(file_name.to_owned().into_string().unwrap());
+        let file_regex = RegEx::create_from_string(file_regex).unwrap();
+        if let Some(regex_match) = file_regex.search(file_name) {
+            return Some(regex_match);
+        }
+    }
+
+    // 2. Folder regex.
+    let folder_regex = project_settings.get_setting(PROJECT_SETTING_LOADER_PATTERN_BY_FOLDER_REGEX.into()).stringify();
+    if !folder_regex.is_empty() {
+        let folder_regex = RegEx::create_from_string(folder_regex).unwrap();
+        for folder in path.iter().rev() {
+            let folder = folder.to_owned().into_string().unwrap();
+            if folder == path::MAIN_SEPARATOR_STR {
+                continue;
+            }
+
+            if let Some(regex_match) = folder_regex.search(folder.into()) {
+                return Some(regex_match);
+            }
+        }
+    }
+
+    // Unable to find a message pattern.
+    None
+}
+
 pub fn compute_locale(path: &PathBuf) -> Option<String> {
     let project_settings = ProjectSettings::singleton();
 
     // 1. File regex.
-    let file_regex = project_settings.get_setting(PROJECT_SETTING_LOCALE_BY_FILE_REGEX.into()).stringify();
+    let file_regex = project_settings.get_setting(PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX.into()).stringify();
     if !file_regex.is_empty() {
         let file_name = path.file_name()?;
         let file_name = GString::from(file_name.to_owned().into_string().unwrap());
@@ -22,7 +61,7 @@ pub fn compute_locale(path: &PathBuf) -> Option<String> {
             if regex_match.get_group_count() > 1 {
                 godot_warn!(
                     "{} is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing. \nUsing last capture group as a fallback.",
-                    PROJECT_SETTING_LOCALE_BY_FILE_REGEX, regex_match.get_group_count()
+                    PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX, regex_match.get_group_count()
                 );
             }
 
@@ -35,7 +74,7 @@ pub fn compute_locale(path: &PathBuf) -> Option<String> {
     }
 
     // 2. Folder regex.
-    let folder_regex = project_settings.get_setting(PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX.into()).stringify();
+    let folder_regex = project_settings.get_setting(PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX.into()).stringify();
     if !folder_regex.is_empty() {
         // Force regex to be case insensitive.
         let folder_regex = "(?i)".to_owned() + &folder_regex.to_string();
@@ -51,7 +90,7 @@ pub fn compute_locale(path: &PathBuf) -> Option<String> {
                 if regex_match.get_group_count() > 1 {
                     godot_warn!(
                         "{} is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing. \nUsing last capture group as a fallback.",
-                        PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX, regex_match.get_group_count()
+                        PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX, regex_match.get_group_count()
                     );
                 }
     

--- a/rust/src/fluent/project_settings.rs
+++ b/rust/src/fluent/project_settings.rs
@@ -7,8 +7,11 @@ const PROJECT_SETTING_PREFIX: &str = "internationalization/fluent/";
 pub(crate) const PROJECT_SETTING_FALLBACK_LOCALE: &str = "internationalization/locale/fallback";
 pub(crate) const PROJECT_SETTING_UNICODE_ISOLATION: &str = constcat!(PROJECT_SETTING_PREFIX, "use_unicode_isolation");
 pub(crate) const PROJECT_SETTING_PARSE_ARGS_IN_MESSAGE: &str = constcat!(PROJECT_SETTING_PREFIX, "parse_args_in_message");
-pub(crate) const PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "locale_by_folder_regex");
-pub(crate) const PROJECT_SETTING_LOCALE_BY_FILE_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "locale_by_file_regex");
+pub(crate) const PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "loader/locale_by_folder_regex");
+pub(crate) const PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "loader/locale_by_file_regex");
+pub(crate) const PROJECT_SETTING_LOADER_PATTERN_BY_FOLDER_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "loader/pattern_by_folder_regex");
+pub(crate) const PROJECT_SETTING_LOADER_PATTERN_BY_FILE_REGEX: &str = constcat!(PROJECT_SETTING_PREFIX, "loader/pattern_by_file_regex");
+pub(crate) const PROJECT_SETTING_LOADER_MESSAGE_PATTERN: &str = constcat!(PROJECT_SETTING_PREFIX, "loader/message_pattern");
 pub(crate) const PROJECT_SETTING_GENERATOR_LOCALES: &str = constcat!(PROJECT_SETTING_PREFIX, "generator/locales");
 pub(crate) const PROJECT_SETTING_GENERATOR_PATTERNS: &str = constcat!(PROJECT_SETTING_PREFIX, "generator/file_patterns");
 pub(crate) const PROJECT_SETTING_GENERATOR_INVALID_MESSAGE_HANDLING: &str = constcat!(PROJECT_SETTING_PREFIX, "generator/invalid_message_handling");
@@ -20,8 +23,11 @@ pub fn register() {
     register_setting(PROJECT_SETTING_UNICODE_ISOLATION.to_string(), false.to_variant());
     // Default to true for default builds (no args parameter), false for forked builds.
     register_setting(PROJECT_SETTING_PARSE_ARGS_IN_MESSAGE.to_string(), cfg!(not(feature = "forked-godot")).to_variant());
-    register_setting(PROJECT_SETTING_LOCALE_BY_FOLDER_REGEX.to_string(), "^.+$".to_variant());
-    register_setting(PROJECT_SETTING_LOCALE_BY_FILE_REGEX.to_string(), "\\.(.+?)\\.ftl$".to_variant());
+    register_setting(PROJECT_SETTING_LOADER_LOCALE_BY_FOLDER_REGEX.to_string(), "^.+$".to_variant());
+    register_setting(PROJECT_SETTING_LOADER_LOCALE_BY_FILE_REGEX.to_string(), "\\.(.+?)\\.ftl$".to_variant());
+    register_setting(PROJECT_SETTING_LOADER_PATTERN_BY_FOLDER_REGEX.to_string(), "".to_variant());
+    register_setting(PROJECT_SETTING_LOADER_PATTERN_BY_FILE_REGEX.to_string(), "".to_variant());
+    register_setting(PROJECT_SETTING_LOADER_MESSAGE_PATTERN.to_string(), "".to_variant());
     register_setting_hint(PROJECT_SETTING_GENERATOR_LOCALES.to_string(), PackedStringArray::new().to_variant(), PropertyHint::NONE, format!("{}/{}:", VariantType::STRING.ord(), PropertyHint::LOCALE_ID.ord()));
     register_setting(PROJECT_SETTING_GENERATOR_PATTERNS.to_string(), Dictionary::new().to_variant());
     register_setting_hint(PROJECT_SETTING_GENERATOR_INVALID_MESSAGE_HANDLING.to_string(), 0.to_variant(), PropertyHint::ENUM, "Skip message,Convert to valid".into());

--- a/rust/src/fluent/translation.rs
+++ b/rust/src/fluent/translation.rs
@@ -9,6 +9,8 @@ use godot::engine::{ITranslation, ProjectSettings, RegEx, Translation};
 use godot::engine::global::Error as GdErr;
 use unic_langid::{LanguageIdentifier, LanguageIdentifierError};
 
+use crate::utils::get_single_regex_match;
+
 use super::project_settings::{PROJECT_SETTING_FALLBACK_LOCALE, PROJECT_SETTING_PARSE_ARGS_IN_MESSAGE, PROJECT_SETTING_UNICODE_ISOLATION};
 
 #[derive(GodotClass)]
@@ -80,16 +82,7 @@ impl TranslationFluent {
         if let Some(regex) = &self.message_pattern_regex {
             // Get actual message and see if it matches.
             if let Some(regex_match) = regex.search(msg.into()) {
-                // Ensure there is only one capture group.
-                if regex_match.get_group_count() > 1 {
-                    godot_warn!(
-                        "message_pattern is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing. \nUsing last capture group as a fallback.",
-                        regex_match.get_group_count()
-                    );
-                }
-
-                // Get the last capture group's value.
-                msg = regex_match.get_string_ex().name(regex_match.get_group_count().to_variant()).done().into();
+                msg = get_single_regex_match(regex_match, "message_pattern").into();
             } else {
                 // Did not match, can not translate.
                 return StringName::default();

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,8 +1,9 @@
+use std::fmt::Display;
 use std::path::PathBuf;
 
 use godot::engine::file_access::ModeFlags;
 use godot::engine::utilities::error_string;
-use godot::engine::FileAccess;
+use godot::engine::{FileAccess, RegExMatch};
 use godot::{engine::DirAccess, prelude::*};
 use godot::engine::global::Error as GdErr;
 
@@ -56,4 +57,17 @@ pub fn create_or_open_file_for_read_write(path: GString) -> Result<Gd<FileAccess
         return Err(FileAccess::get_open_error());
     }
     Ok(fa.unwrap())
+}
+
+pub fn get_single_regex_match<T: Display>(regex_match: Gd<RegExMatch>, err_source: T) -> GString {
+    // Ensure there is only one capture group.
+    if regex_match.get_group_count() > 1 {
+        godot_warn!(
+            "{} is set to a RegEx with {} capture groups. Only one should be capturing, the rest should be (?:) non-capturing.\nUsing last capture group as a fallback.",
+            err_source, regex_match.get_group_count()
+        );
+    }
+
+    // Get the last capture group's value.
+    regex_match.get_string_ex().name(regex_match.get_group_count().to_variant()).done()
 }


### PR DESCRIPTION
Set `message_pattern` to a regex value which allows prefixing/suffixing messages with constant values (e.g. taking directories and file name into account). Regex group is used to match the actual message.

ProjectSettings are split into two parts. First extract pattern strings from filename or foldername, then use whichever matched to build another regex for the actual message pattern.