### PR TITLE
Fix integer formatting breaking selectors

### DIFF
--- a/rust/src/fluent/translation.rs
+++ b/rust/src/fluent/translation.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use fluent::types::{FluentNumber, FluentNumberOptions};
+use fluent::types::FluentNumber;
 use fluent::{FluentArgs, FluentBundle, FluentError, FluentResource, FluentValue};
 use godot::prelude::*;
 use godot::classes::{ITranslation, ProjectSettings, RegEx, Translation};
@@ -176,9 +176,7 @@ impl TranslationFluent {
             },
             VariantType::INT => {
                 let casted: i64 = input.to();
-                let mut options = FluentNumberOptions::default();
-                options.maximum_fraction_digits = Some(0);
-                FluentValue::Number(FluentNumber::new(casted as f64, options))
+                FluentValue::Number(FluentNumber::new(casted as f64, Default::default()))
             }
             VariantType::FLOAT => {
                 let casted: f64 = input.to();


### PR DESCRIPTION
When setting maximum_fraction_digits, I assume the result is a string, which breaks selectors over int values.

Now to select float values you must specify the selector like `[1.0]` and for int values you must specify `[1]`.