### PR TITLE
Fix editor crash issues

### DIFF
--- a/godot/default/addons/godot-fluent-translation/godot-fluent-translation.gdextension
+++ b/godot/default/addons/godot-fluent-translation/godot-fluent-translation.gdextension
@@ -1,7 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.3
-reloadable = true
 
 [libraries]
 linux.debug.x86_64 =     "res://../../rust/target/debug/libgodot_fluent_translation.so"

--- a/godot/forked/addons/godot-fluent-translation/godot-fluent-translation.gdextension
+++ b/godot/forked/addons/godot-fluent-translation/godot-fluent-translation.gdextension
@@ -1,7 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.3
-reloadable = true
 
 [libraries]
 linux.debug.x86_64 =     "res://../../rust/target/debug/libgodot_fluent_translation.so"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -141,7 +141,8 @@ dependencies = [
 [[package]]
 name = "gdextension-api"
 version = "0.2.1"
-source = "git+https://github.com/godot-rust/godot4-prebuilt?branch=releases#53fa4a856d93ac01d87deb8f57c6851179dfacec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8707eca996b28193b772a4a9a28a97364bb93c97e3c313542e812f2963fb93"
 
 [[package]]
 name = "gensym"
@@ -180,8 +181,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "godot"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e3303596db8308e151ed0aad65137ece9411de36c245133183351ece59534"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -189,8 +191,9 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed68172573440c57e7889fc3081f1ea06ec30c0a585d958a0937e2974ebc83a1"
 dependencies = [
  "bindgen",
  "gdextension-api",
@@ -200,13 +203,15 @@ dependencies = [
 
 [[package]]
 name = "godot-cell"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2232f67f36f51bcbc5af7fbca12623dc8bd44669ac9200568be9083bda61db"
 
 [[package]]
 name = "godot-codegen"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91dd872b60f4fb0695ae7e142247e66e9db2093417d6375336dd13a91f513802"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -218,8 +223,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0824b7366bee542d3134ba28fd527ba009eb657a0c324b1db825746db4fdc7"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -230,8 +236,9 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a10e4617f79690a75187b13693b1aeb2dc4615498747dd58129feb1335e5ae1"
 dependencies = [
  "gensym",
  "godot-bindings",
@@ -254,8 +261,9 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#f40fa274644c4ed5458fbc5fd6d587d8a3b9e4e3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbec357a02d05f1a3ef5044c18b2c65a2d3915ea29da68cfb2a5f0681aec6da"
 dependencies = [
  "godot-bindings",
  "markdown",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,6 @@ crate-type = ["cdylib"]  # Compile this crate to a dynamic C library.
 constcat = "0.5.0"
 fluent = { git = "https://github.com/projectfluent/fluent-rs", branch = "main" }
 fluent-syntax = { git = "https://github.com/projectfluent/fluent-rs", branch = "main" }
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = ["register-docs", "lazy-function-tables"] }
+godot = { version = "0.2.1", features = ["register-docs", "lazy-function-tables"] }
 itertools = "0.13.0"
 unic-langid = "0.9.4"

--- a/rust/src/fluent/global.rs
+++ b/rust/src/fluent/global.rs
@@ -1,5 +1,5 @@
 use godot::prelude::*;
-use godot::classes::ResourceLoader;
+use godot::classes::{Engine, ResourceLoader};
 
 use super::ResourceFormatLoaderFluent;
 
@@ -7,17 +7,23 @@ use super::ResourceFormatLoaderFluent;
 #[derive(GodotClass)]
 #[class(base=Object, init)]
 pub struct FluentI18nSingleton {
-    loader: Gd<ResourceFormatLoaderFluent>,
+    loader: Option<Gd<ResourceFormatLoaderFluent>>,
 }
 
 impl FluentI18nSingleton {
     pub(crate) const SINGLETON_NAME: &'static str = "FluentI18nSingleton";
 
-    pub(crate) fn register(&self) {
-        ResourceLoader::singleton().add_resource_format_loader(&self.loader);
+    pub(crate) fn register(&mut self) {
+        // HACK: Resource format loader crashes editor on startup, see https://github.com/godot-rust/gdext/issues/597
+        if !Engine::singleton().is_editor_hint() {
+            self.loader = Some(ResourceFormatLoaderFluent::new_gd());
+            ResourceLoader::singleton().add_resource_format_loader(&self.loader.clone().unwrap());
+        }
     }
 
     pub(crate) fn unregister(&self) {
-        ResourceLoader::singleton().remove_resource_format_loader(&self.loader);
+        if let Some(loader) = &self.loader {
+            ResourceLoader::singleton().remove_resource_format_loader(loader);
+        }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,8 +25,8 @@ unsafe impl ExtensionLibrary for FluentI18n {
         if level == InitLevel::Scene {
             project_settings::register();
 
-            let singleton = FluentI18nSingleton::new_alloc();
-            singleton.bind().register();
+            let mut singleton = FluentI18nSingleton::new_alloc();
+            singleton.bind_mut().register();
 
             Engine::singleton()
                 .register_singleton(FluentI18nSingleton::SINGLETON_NAME, &singleton);


### PR DESCRIPTION
- Update to stable 0.2.1 build of godot-rust to avoid the master branch breakages.
- Fix #25 by just disabling reloadable.
- Workaround the crashes in editor by disabling the resource loader when in editor. While this makes .ftl files no longer show in the editor, everything else should still work as expected at runtime. See #54